### PR TITLE
Version 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    qbert (0.1.0)
+    qbert (0.1.1)
       aws-sdk-sqs (~> 1.36)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.425.0)
+    aws-partitions (1.428.0)
     aws-sdk-core (3.112.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)

--- a/lib/qbert.rb
+++ b/lib/qbert.rb
@@ -8,16 +8,16 @@ module Qbert
   class Error < StandardError; end
 
   class << self
-    def put_message message
-      client.put_message message
+    def put_message message, queue_url = nil
+      client(queue_url).put_message message
     end
 
-    def get_messages
-      client.get_messages
+    def get_messages queue_url = nil
+      client(queue_url).get_messages
     end
 
-    def client
-      Client.new
+    def client queue_url = nil
+      Client.new queue_url
     end
   end
 end

--- a/lib/qbert/client.rb
+++ b/lib/qbert/client.rb
@@ -4,11 +4,12 @@ require "aws-sdk-sqs"
 
 module Qbert
   class Client
-    attr_reader :client, :action_result
+    attr_reader :client, :action_result, :queue_url
 
-    def initialize
+    def initialize queue_url = nil
       @client = Aws::SQS::Client.new region: Qbert.configurable.region,
                                      credentials: Qbert.configurable.credentials
+      @queue_url = queue_url || Qbert.configurable.queue_url
     end
 
     def put_message(message)
@@ -29,10 +30,6 @@ module Qbert
       {
         queue_url: queue_url
       }.merge(params)
-    end
-
-    def queue_url
-      Qbert.configurable.queue_url
     end
 
     def messages

--- a/lib/qbert/configurable.rb
+++ b/lib/qbert/configurable.rb
@@ -4,7 +4,7 @@ require "aws-sdk-sqs"
 
 module Qbert
   class Configurable
-    attr_accessor :region, :access_key_id, :secret_access_key
+    attr_accessor :queue_url, :region, :access_key_id, :secret_access_key
 
     def credentials
       (@credentials || aws_credentials)

--- a/lib/qbert/configurable.rb
+++ b/lib/qbert/configurable.rb
@@ -4,7 +4,7 @@ require "aws-sdk-sqs"
 
 module Qbert
   class Configurable
-    attr_accessor :queue_url, :region, :access_key_id, :secret_access_key
+    attr_accessor :region, :access_key_id, :secret_access_key
 
     def credentials
       (@credentials || aws_credentials)

--- a/lib/qbert/version.rb
+++ b/lib/qbert/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Qbert
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
This PR allows for the queue_url to be optionally passed into the put_messages and get_messages methods. This will allow the gem to be able to access multiple queues.